### PR TITLE
Updated leave and join

### DIFF
--- a/cogs.py
+++ b/cogs.py
@@ -1,6 +1,6 @@
 from discord.ext import commands, tasks
 from dotenv import load_dotenv
-from re import search
+from re import search, sub
 import discord
 import os
 import scripts as s
@@ -24,6 +24,9 @@ class Classes(commands.Cog):
         guild = discord.utils.get(self.bot.guilds, name=GUILD)
         roles = await guild.fetch_roles()
         major = ' '.join(major).lower()
+        if major == 'help':
+            await ctx.send(self.major.help)
+            return
         if major.upper() in major_abbrev:
             major = major_abbrev[major.upper()].lower()
         selected_role = [i for i in roles if i.name.lower() == major]
@@ -39,86 +42,118 @@ class Classes(commands.Cog):
         await ctx.author.add_roles(selected_role[0])
 
 
-    async def validate_class(self, ctx, class_name, class_number):
-        if class_number:
-            department = class_name.lower()
+    async def validate_class(self, ctx, class_name):
+        match = search(r'\A\D+', class_name)
+        if match is None:
+            await ctx.send(f'Unrecognized course name: {class_name}\n' \
+                           f'Please include a valid department prefix.')
+            return
         else:
-            match = search(r'\A\D+', class_name)
-            if match is None:
-                await ctx.send('Invalid class name, please include department prefix')
-                return
-            else:
-                department = match.group().lower()
-                class_number = class_name[len(department):]
+            department = match.group().lower()
+            class_number = class_name[len(department):]
         try:
             class_int = int(class_number)
             if class_int < 1000 or class_int > 8000:
+                print(f'Bad range for class number: {class_int}')
                 await ctx.send(f'Invalid class number: {class_number}')
                 return
         except ValueError:
+            print(f'Caught ValueError on class number: {class_number}')
             await ctx.send(f'Invalid class number: {class_number}')
             return
         dep_length = len(department)
         if dep_length > 4 or dep_length < 2:
-            await ctx.send('Invalid department prefix')
+            await ctx.send(f'Invalid department prefix: {department}')
             return
         return department, class_number
 
-    @commands.command(help='Join the text channel for a specified class.\nExample: $join CS1120',
+    @commands.command(help='Join the text channel for a specified class.\nExample: $join CS1120\n\n' \
+                           'You may also type several classes at once in a comma-separated list.\n' \
+                           'Example: $join cs1120, math 2240, phys-2130',
                       brief='Join the text channel for a specified class.')
-    async def join(self, ctx, class_name, class_number=None):
+    async def join(self, ctx, *, arg):
+        arg = arg.strip().lower()
+        if arg == 'help':
+            await ctx.send(self.join.help)
+            return
         guild = discord.utils.get(self.bot.guilds, name=GUILD)
-        class_info = await self.validate_class(ctx, class_name, class_number)
-        if class_info is None:
-            return
-        department, class_number = class_info
-        category = [i for i in guild.categories if i.name == department]
-        overwrites = {
-            guild.default_role: discord.PermissionOverwrite(read_messages=False),
-            guild.me: discord.PermissionOverwrite(read_messages=True)
-        }
-        if len(category) == 0:
-            print(f'Creating category {department}')
-            category = await guild.create_category(department, overwrites=overwrites)
-        else:
-            category = category[0]
-        class_name = department + class_number
-        channel = [i for i in category.text_channels if i.name == class_name]
-        if len(channel) > 0:
-            print(f'Adding user to channel {class_name}')
-            await channel[0].set_permissions(ctx.author, read_messages=True)
-            return
-        print(f'Creating channel {class_name}')
-        channel = await guild.create_text_channel(class_name, overwrites=overwrites, category=category)
-        await channel.set_permissions(ctx.author, read_messages=True)
+        successful_joins = []
+        for element in arg.split(','):
+            class_name = sub(r'[\s\-]', '', element)
+            class_info = await self.validate_class(ctx, class_name)
+            if class_info is None:
+                await ctx.send(f'Course "{class_name.strip()}" not joined.')
+                continue
+            department, class_number = class_info
+            category = [i for i in guild.categories if i.name == department]
+            overwrites = {
+                guild.default_role: discord.PermissionOverwrite(read_messages=False),
+            }
+            if len(category) == 0:
+                print(f'Creating category {department}')
+                category = await guild.create_category(department, overwrites=overwrites)
+            else:
+                category = category[0]
+            class_name = department + class_number
+            channel = [i for i in category.text_channels if i.name == class_name]
+            if len(channel) > 0:
+                print(f'Adding user {ctx.author.name} to channel {class_name}')
+                await channel[0].set_permissions(ctx.author, read_messages=True)
+            else:
+                print(f'Creating channel {class_name}')
+                channel = await guild.create_text_channel(class_name, 
+                                                          overwrites=overwrites, 
+                                                          category=category)
+                await channel.set_permissions(ctx.author, read_messages=True)
+            successful_joins.append(class_name)
+        if successful_joins:
+            await ctx.send(f'Successfully joined text channels for: {", ".join(successful_joins)}')
+            
 
     @join.error
     async def join_error(self, ctx, error):
         if isinstance(error, commands.errors.MissingRequiredArgument):
-            await ctx.send('You must include a class with this command.\n'
+            await ctx.send('You must include at least one class with this command.\n'
                            'Example: $join CS1120\n\n'
                            'Please use *$help join* for more information.')
         else:
             print(f'$join command failed with error:\n\n{error}')
 
-    @commands.command(help='Leave the text channel for a specified class.\nExample: $leave CS1120',
+    @commands.command(help='Leave the text channel for a specified class.\nExample: $leave CS1120\n\n' \
+                           'You may also type several classes at once in a comma-separated list.\n' \
+                           'Example: $leave cs1120, math 2240, phys-2130',
                       brief='Leave the text channel for a specified class.')
-    async def leave(self, ctx, class_name, class_number=None):
-        guild = discord.utils.get(self.bot.guilds, name=GUILD)
-        class_info = await self.validate_class(ctx, class_name, class_number)
-        if class_info is None:
+    async def leave(self, ctx, *, arg):
+        arg = arg.strip().lower()
+        if arg == 'help':
+            await ctx.send(self.leave.help)
             return
-        department, class_number = class_info
-        category = [i for i in guild.categories if i.name == department]
-        if len(category) > 0:
-            channel = [i for i in category[0].text_channels if i.name == class_name]
-            if len(channel) > 0:
-                await channel[0].set_permissions(ctx.author, read_messages=False)
+        guild = discord.utils.get(self.bot.guilds, name=GUILD)
+        successful_leaves = []
+        for element in arg.split(','):
+            class_name = sub(r'[\s\-]', '', element)
+            class_info = await self.validate_class(ctx, class_name)
+            if class_info is None:
+                await ctx.send(f'Course "{class_name.strip()}" not left.')
+                continue
+            department, class_number = class_info
+            category = [i for i in guild.categories if i.name == department]
+            if len(category) > 0:
+                channel = [i for i in category[0].text_channels if i.name == class_name]
+                if len(channel) > 0:
+                    await channel[0].set_permissions(ctx.author, read_messages=False)
+                    successful_leaves.append(class_name)
+                else:
+                    await ctx.send(f'No channel with name "{class_name}" found, channel not left.')
+            else:
+                await ctx.send(f'No category with name "{department}" found, channel not left.')
+        if successful_leaves:
+            await ctx.send(f'Successfully left text channels for: {", ".join(successful_leaves)}')
 
     @leave.error
     async def leave_error(self, ctx, error):
         if isinstance(error, commands.errors.MissingRequiredArgument):
-            await ctx.send('You must include a class with this command.\n'
+            await ctx.send('You must include at least one class with this command.\n'
                            'Example: $leave CS1120\n\n'
                            'Please use *$help leave* for more information.')
         else:
@@ -201,8 +236,9 @@ class Utility(commands.Cog):
     async def info(self, ctx):
         await ctx.send(f'Hello! I am BUSTER, your friendly automation bot!\n' \
                        f'I was developed by WMU students, and am hosted locally in Kalamazoo!\n' \
-                       f'If you want to know me more intimately my Open Source code can be found here:' \
-                       f'\n\nhttps://github.com/vscheff/BUSTER')
+                       f'If you would like to know me more intimately ' \
+                       f'my Open Source code can be found here:\n\n' \
+                       f'https://github.com/vscheff/BUSTER')
                     
     @commands.command(hidden=True)
     async def ready(self, ctx):


### PR DESCRIPTION
The $join and $leave commands now accept multiple classes in one command, including classes with white space and/or hyphen separation. The accompanying validate_classes function was modified slightly as "class_number" is no longer an argument to be expected from users.