### PR TITLE
Fixed $major Exploit

### DIFF
--- a/Cogs/Classes.py
+++ b/Cogs/Classes.py
@@ -12,11 +12,14 @@ GUILD = getenv('DISCORD_GUILD')
 class Classes(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.not_majors = ['Admin', 'WMU_Buster_Clone_Bot', 'Professor']
+        self.major_list = []
+        with open('message.txt', 'r') as inFile:
+            for line in inFile:
+                self.major_list.append(line.strip().lower())
 
-    @commands.command(help='Select your major as a server role.\nExample: $major Computer Science\n\n' \
-                           'To view a list of supported majors, ' \
-                           'use the command with 0 arguments\nExample: $major\n\n' \
+    @commands.command(help='Select your major as a server role.\nExample: $major Computer Science\n\n'
+                           'To view a list of supported majors, '
+                           'use the command with 0 arguments\nExample: $major\n\n'
                            'For some majors you may also use their abbreviation code\nExample: $major AAAS',
                       brief='Select your major as a server role.')
     async def major(self, ctx, *major):
@@ -28,22 +31,19 @@ class Classes(commands.Cog):
             return
         if major.upper() in major_abbrev:
             major = major_abbrev[major.upper()].lower()
-        selected_role = [i for i in roles if i.name.lower() == major]
-        if len(selected_role) == 0:
-            if major:
-                await ctx.send(f'Invald major! Please be sure to type your major exactly as it appears.')
-            await ctx.send(content=f'Supported majors include:\n', file=discord.File('./message.txt', filename='Majors.txt'))
+        elif major not in self.major_list:
+            await ctx.send('Invalid major! Please be sure to type your major exactly as it appears.')
+            await ctx.send(content=f'Supported majors include:\n', 
+                           file=discord.File('./message.txt', filename='Majors.txt'))
             return
-        if selected_role[0].name in self.not_majors:
-            await ctx.send('Sorry, that role is unavailable for assigment. Please type a valid major.')
-            return
-        await ctx.send(f'Success! You are now a member of {selected_role[0].name}!')
-        await ctx.author.add_roles(selected_role[0])
+        selected_role = [i for i in roles if i.name.lower() == major][0]
+        await ctx.send(f'Success! You are now a member of {selected_role.name}!')
+        await ctx.author.add_roles(selected_role)
 
     async def validate_class(self, ctx, class_name):
         match = search(r'\A\D+', class_name)
         if match is None:
-            await ctx.send(f'Unrecognized course name: {class_name}\n' \
+            await ctx.send(f'Unrecognized course name: {class_name}\n'
                            f'Please include a valid department prefix.')
             return
         else:
@@ -165,7 +165,7 @@ class Classes(commands.Cog):
             with open(filename, 'r') as inFile:
                 role_objects = await guild.fetch_roles()
                 role_names = [i.name for i in role_objects]
-                color = discord.Colour.gold()
+                color = discord.Colour.orange()
                 count_success = 0
                 count_failure = 0
                 await ctx.send('Beginning bulk role creation...')

--- a/Cogs/LoopTasks.py
+++ b/Cogs/LoopTasks.py
@@ -22,7 +22,7 @@ class LoopTasks(commands.Cog):
     @tasks.loop(hours=24)
     async def purge_channels(self):
         print(f'Beginning default channel purge #{self.purge_channels.current_loop}:')
-        del_before = datetime.now() - timedelta(hours=76)
+        del_before = datetime.now() - timedelta(hours=72)
         print(f'Deleting messages before {del_before}')
         for channel in (self.ch_welcome, self.ch_roleClaim):
             await self.delete_messages(channel, del_before)
@@ -34,8 +34,8 @@ class LoopTasks(commands.Cog):
         
     @purge_channels.before_loop
     async def before_purge(self):
-        print('Starting default channel purge 24 hour loop')
-        await self.bot.wait_until_ready()
+        await self.bot.wait_until_ready()        
+        print('Starting default channel purge 24 hour loop')        
         self.guild = discord.utils.get(self.bot.guilds, name=GUILD)
         self.ch_welcome = self.guild.get_channel(WELCOME_CHANNEL_ID)
         if self.ch_welcome is None:


### PR DESCRIPTION
The Classes cog now builds a list of majors from message.txt. This is used by the $major command to validate the user's input for their major. This means any arbitrary role can be added, and any non-major role can be renamed without worry of that role becoming joinable through the $major command.